### PR TITLE
Reformatted Changes file according to CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,54 +1,51 @@
-=head1 Revision history for IUP
+Revision history for perl module IUP
 
-=head2 XX/XX/2013 - 0.102
+0.101 2013-07-31
 
- - XXX
+    - fixing broken links to examples
 
-=head2 31/07/2013 - 0.101
+0.100 2013-02-06
 
- - fixing broken links to examples
+    - updating callbacks newly added in iup 3.6/3.7
+    - starting new version line
 
-=head2 06/02/2013 - 0.100
+0.006 2012-08-12
 
- - updating callbacks newly added in iup 3.6/3.7
- - starting new version line
+    - attribute accesors now handled via AUTOLOAD
+    - Callback.xs+Canvas.xs incorporated into IupLibrary.xs
+    - improved thread awareness of Idle callback
+    - preparing for iup-3.6
 
-=head2 12/08/2012 - 0.006
+0.004 2011-08-19
 
- - attribute accesors now handled via AUTOLOAD
- - Callback.xs+Canvas.xs incorporated into IupLibrary.xs
- - improved thread awareness of Idle callback
- - preparing for iup-3.6
+    - forcing newer Alien::IUP (to make IUP install smoothly on cygwin)
+    - fixing cygwin build failures
 
-=head2 19/08/2011 - 0.004
+0.003 2011-08-18
 
- - forcing newer Alien::IUP (to make IUP install smoothly on cygwin)
- - fixing cygwin build failures
+    - much better documentation
+    - many fixes for IUP::Canvas methods
+    - added: IUP::Canvas::(Palette|Pattern|Stipple|Bitmap) -
+      canvas helper modules
+    - added: IUP::Canvas::(InternalState|InternalServerImage|InternalContext)
+      canvas helper modules (hidden)
+    - added: IUP::Canvas::FileBitmap
+    - added: IUP::Canvas::FileVector - replacement for IUP::Canvas::(SVG|EMF)
+    - added: IUP::ConfigData
+    - fix for callbacks: better handling of callbacks with no return value
+      (fallback to IUP_DEFAULT)
+    - fix for callbacks: MULTITOUCH_CB, MULTISELECTION_CB,
+      MULTIUNSELECTION_CB, NODEREMOVED_CB
+    - removing debug stuff 'use Data::Dump(er)'
 
-=head2 18/08/2011 - 0.003
+0.002 2011-07-29
 
- - much better documentation
- - many fixes for IUP::Canvas methods
- - added: IUP::Canvas::(Palette|Pattern|Stipple|Bitmap) - canvas helper modules
- - added: IUP::Canvas::(InternalState|InternalServerImage|InternalContext) - canvas helper modules (hidden)
- - added: IUP::Canvas::FileBitmap
- - added: IUP::Canvas::FileVector - replacement for IUP::Canvas::(SVG|EMF)
- - added: IUP::ConfigData
- - fix for callbacks: better handling of callbacks with no return value (fallback to IUP_DEFAULT)
- - fix for callbacks: MULTITOUCH_CB, MULTISELECTION_CB, MULTIUNSELECTION_CB, NODEREMOVED_CB
- - removing debug stuff 'use Data::Dump(er)'
+    - removing invalid accessors "0" and "1"
+    - fix for "Can't locate IUP/OleControl.pm"
+    - fixing documentation
 
-=head2 29/07/2011 - 0.002
+0.001_01 2011-07-19
 
- - removing invalid accessors "0" and "1"
- - fix for "Can't locate IUP/OleControl.pm"
- - fixing documentation
-
-=head2 19/07/2011 - 0.001_01
-
- - the first CPAN release
-
-=head2 15/09/2010 - 0.000
-
- - initial proof-of-concept version uploaded to github
- - https://github.com/kmx/perl-iup/commit/e8cb0bb10e4ce6e7a342f65a6b933bbd90c1fb6d
+    - the first CPAN release
+    - initial proof-of-concept (0.000) version uploaded to github 2010-09-15
+      https://github.com/kmx/perl-iup/commit/e8cb0bb10e4ce6e7a342f65a6b933bbd90c1fb6d


### PR DESCRIPTION
Hi,

I've reformatted your Changes file according to the spec in CPAN::Changes::Spec.

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's CPAN::Changes Kwalitee Service (http://changes.cpanhq.org),
which is where I saw your module listed :-)

Cheers,
Neil

I'm doing this because I'm on a [quest](http://questhub.io/realm/perl/quest/51f0337718ba7d3959000086) to help improve CPAN. You could adjust all of [your dists](http://changes.cpanhq.org/author/KMX) this way, and log them on our quest, if you'd like to help :-)
